### PR TITLE
Compatibility with python 3.7

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Contributors
 ============
 Krzysztof Bujniewicz, 2015-10-27
 Henrik Heimbuerger, 2016-10-23
+Andrzej Buczyński, 2018-07-05

--- a/MANIFEST
+++ b/MANIFEST
@@ -3,5 +3,5 @@ setup.cfg
 setup.py
 devourer/__init__.py
 devourer/api.py
-devourer/async.py
+devourer/async_api.py
 devourer/tests.py

--- a/devourer/__init__.py
+++ b/devourer/__init__.py
@@ -41,4 +41,4 @@ None instead when they happen with `throw_on_error=False`.
 
 """
 from .api import GenericAPI, APIMethod, APIError, PrepareCallArgs, GenericAPICreator, GenericAPIBase
-from .async import AsyncAPI, AsyncAPIBase
+from .async_api import AsyncAPI, AsyncAPIBase

--- a/devourer/async_api.py
+++ b/devourer/async_api.py
@@ -1,5 +1,5 @@
 """
-.. module:: async
+.. module:: async_api
     :platform: Unix, Windows
     :synopsis: This module extends basic api with gevent-based async capabilities.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='devourer',
     packages=['devourer'],
-    version='0.4.7',
+    version='0.4.8',
     install_requires=[
         'requests',
         'futures',
@@ -14,7 +14,7 @@ setup(
     author='Bonnier Business Polska / Krzysztof Bujniewicz',
     author_email='racech@gmail.com',
     url='https://github.com/bonnierpolska/devourer',
-    download_url='https://github.com/bonnierpolska/devourer/tarball/0.4.5',
+    download_url='https://github.com/bonnierpolska/devourer/tarball/0.4.8',
     keywords=['api', 'generic api', 'api client'],
     classifiers=[]
 )


### PR DESCRIPTION
In accordance with [this](https://docs.python.org/3/whatsnew/3.7.html), as of python 3.7 async is reserved keyword. This pull request adds compatibility with python 3.7 by renaming async.py into async_api.py